### PR TITLE
Use gh instead of hub on Linux

### DIFF
--- a/linux.conf.yaml
+++ b/linux.conf.yaml
@@ -11,7 +11,7 @@
 
 - brew:
     - fzf
-    - hub
+    - gh
     - python@3.9
     - rbenv
     - ripgrep


### PR DESCRIPTION
Closes #5

Replaces the obsolete Linux `hub` package with GitHub's `gh` CLI to match the Mac configuration.