### PR TITLE
Fix Neovim Mason and plugin loading

### DIFF
--- a/configs/nvim/init.lua
+++ b/configs/nvim/init.lua
@@ -5,11 +5,3 @@ require("tanner.lazy")
 vim.cmd.colorscheme("rose-pine")
 
 -- AI ASSIST
--- Sourcegraph configuration. All keys are optional
-require("sg").setup({
-  -- Pass your own custom attach function
-  --    If you do not pass your own attach function, then the following maps are provide:
-  --        - gd -> goto definition
-  --        - gr -> goto references
-  -- on_attach = your_custom_lsp_attach_function
-})

--- a/configs/nvim/lua/tanner/plugins/lsp/config.lua
+++ b/configs/nvim/lua/tanner/plugins/lsp/config.lua
@@ -10,12 +10,6 @@ return {
     { "folke/lazydev.nvim", ft = "lua" }, -- properly configures LuaLS for editing your Neovim config
   },
   config = function()
-    -- import lspconfig plugin
-    local lspconfig = require("lspconfig")
-
-    -- import mason_lspconfig plugin
-    local mason_lspconfig = require("mason-lspconfig")
-
     -- import cmp-nvim-lsp plugin
     local cmp_nvim_lsp = require("cmp_nvim_lsp")
 
@@ -82,30 +76,26 @@ return {
       vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = "" })
     end
 
-    mason_lspconfig.setup_handlers({
-      -- default handler for installed servers
-      function(server_name)
-        lspconfig[server_name].setup({
-          capabilities = capabilities,
-        })
-      end,
-      ["lua_ls"] = function()
-        -- configure lua server (with special settings)
-        lspconfig["lua_ls"].setup({
-          capabilities = capabilities,
-          settings = {
-            Lua = {
-              -- make the language server recognize "vim" global
-              diagnostics = {
-                globals = { "vim" },
-              },
-              completion = {
-                callSnippet = "Replace",
-              },
+    local server_configs = {
+      lua_ls = {
+        settings = {
+          Lua = {
+            diagnostics = {
+              globals = { "vim" },
+            },
+            completion = {
+              callSnippet = "Replace",
             },
           },
-        })
-      end,
-    })
+        },
+      },
+    }
+
+    for _, server_name in ipairs({ "ts_ls", "html", "cssls", "tailwindcss", "lua_ls" }) do
+      local config = server_configs[server_name] or {}
+      config.capabilities = capabilities
+      vim.lsp.config(server_name, config)
+      vim.lsp.enable(server_name)
+    end
   end,
 }

--- a/configs/nvim/lua/tanner/plugins/lsp/mason.lua
+++ b/configs/nvim/lua/tanner/plugins/lsp/mason.lua
@@ -28,7 +28,7 @@ return {
     mason_lspconfig.setup({
       -- list of servers for mason to install
       ensure_installed = {
-        "tsserver",
+        "ts_ls",
         "html",
         "cssls",
         "tailwindcss",

--- a/configs/nvim/lua/tanner/plugins/rose-pine.lua
+++ b/configs/nvim/lua/tanner/plugins/rose-pine.lua
@@ -1,7 +1,0 @@
-return {
-	"rose-pine/neovim",
-	name = "rose-pine",
-	config = function()
-		vim.cmd("colorscheme rose-pine")
-	end
-}

--- a/configs/nvim/lua/tanner/plugins/sourcegraph.lua
+++ b/configs/nvim/lua/tanner/plugins/sourcegraph.lua
@@ -4,5 +4,8 @@ return {
   {
     "sourcegraph/sg.nvim",
     dependencies = { "nvim-lua/plenary.nvim", "nvim-telescope/telescope.nvim" },
+    config = function()
+      require("sg").setup({})
+    end,
   },
 }


### PR DESCRIPTION
Closes #6

Updates LSP setup for the current Neovim API, renames `tsserver` to `ts_ls`, makes Sourcegraph setup lazy, and removes the duplicate Rose Pine plugin declaration.