### PR TITLE
feat(ghostty): add boilerplate config and symlink it on install

### DIFF
--- a/configs/ghostty/config
+++ b/configs/ghostty/config
@@ -1,5 +1,15 @@
 # Ghostty configuration
 # https://ghostty.org/docs/config
+#
+# Syntax is `key = value`; comments must be on their own line.
+# An empty value (`key =`) resets that option back to its default.
+#
+# Useful commands:
+#   ghostty +show-config --default --docs   # every option, documented
+#   ghostty +list-themes                    # available themes
+#   ghostty +list-fonts                     # available fonts
+#
+# Reload this file at runtime with ctrl+shift+, (Linux) / cmd+shift+, (macOS).
 
 ##
 # THEME
@@ -7,3 +17,56 @@
 # Use Rose Pine, following the system light/dark appearance
 # https://rosepinetheme.com/
 theme = light:Rose Pine Dawn,dark:Rose Pine Moon
+
+##
+# FONT
+
+# Uncomment to override the system monospace default.
+# https://www.recursive.design/
+# font-family = RecMonoLinear Nerd Font Mono
+font-size = 14
+
+##
+# WINDOW
+
+# Breathing room between the text and the window edge
+window-padding-x = 4
+window-padding-y = 4
+
+# Open new windows/tabs in the current window's working directory
+window-inherit-working-directory = true
+
+# Follow the theme's light/dark appearance for window chrome
+window-theme = auto
+
+# Uncomment for a transparent background (1 = opaque, 0 = transparent)
+# background-opacity = 0.95
+
+##
+# CURSOR
+
+cursor-style = block
+cursor-style-blink = false
+
+# Get the cursor out of the way while typing
+mouse-hide-while-typing = true
+
+##
+# SCROLLBACK & CLIPBOARD
+
+# Scrollback buffer per surface, in bytes (default is 10MB)
+scrollback-limit = 10000000
+
+# Drop trailing whitespace from copied text
+clipboard-trim-trailing-spaces = true
+
+# Follow URLs on hover + ctrl (Linux) / cmd (macOS)
+link-url = true
+
+##
+# KEYBINDINGS
+
+# Syntax is `keybind = trigger=action`.
+# See https://ghostty.org/docs/config/keybind for triggers and actions.
+# example:
+# keybind = ctrl+shift+r=reload_config

--- a/default.conf.yaml
+++ b/default.conf.yaml
@@ -5,12 +5,13 @@
     - ~/.git_template/hooks
     - ~/.ctags.d
     - ~/.shellrc
+    - ~/.config/ghostty
 
 - link:
     ~/.bashrc: configs/bashrc
     ~/.claude/commands: configs/claude/commands
     ~/.claude/settings.json: configs/claude/settings.json
-    ~/.config/ghostty: configs/ghostty
+    ~/.config/ghostty/config: configs/ghostty/config
     ~/.config/nvim: configs/nvim
     ~/.ctags.d/.ctags: configs/ctags
     ~/.env: configs/env


### PR DESCRIPTION
Track a documented starter Ghostty config covering font, window, cursor,
scrollback/clipboard and keybinding sections, keeping the existing Rose
Pine light/dark theme.

Link ~/.config/ghostty/config at the file level rather than symlinking
the whole directory, so machine-local additions (custom themes, etc.)
can live alongside it. Add ~/.config/ghostty to the create list; dotbot
does not make parent directories on its own, so the previous directory
link silently failed on machines without ~/.config.

Closes #16

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>